### PR TITLE
提案: 環境変数の設定を.envファイルとdockerfileの両方に書く必要がある部分を修正

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -16,6 +16,8 @@ services:
         # network setting
         - http_proxy=${HTTP_PROXY}
         - https_proxy=${HTTPS_PROXY}
+        - HTTP_PROXY=${HTTP_PROXY}
+        - HTTPS_PROXY=${HTTPS_PROXY}
     volumes:
       # Forwards the local Docker socket to the container.
       - /var/run/docker.sock:/var/run/docker-host.sock

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -28,6 +28,11 @@ services:
     entrypoint: /usr/local/share/docker-init.sh
     command: sleep infinity
     environment:
+      # network setting
+      - http_proxy=${HTTP_PROXY}
+      - https_proxy=${HTTPS_PROXY}
+      - HTTP_PROXY=${HTTP_PROXY}
+      - HTTPS_PROXY=${HTTPS_PROXY}
       # poetry setting environments
       - POETRY_VIRTUALENVS_CREATE=false
       - POETRY_VIRTUALENVS_IN_PROJECT=true

--- a/.devcontainer/environment/ubuntu/Dockerfile
+++ b/.devcontainer/environment/ubuntu/Dockerfile
@@ -14,14 +14,6 @@ ARG USE_MOBY="true"
 
 # Enable new "BUILDKIT" mode for Docker CLI
 ENV DOCKER_BUILDKIT=1
-# Install needed packages and setup non-root user. Use a separate RUN statement to add your
-# own dependencies. A user of "automatic" attempts to reuse an user ID if one already exists.
-ARG USERNAME=vscode
-ARG USER_UID=1000
-ARG USER_GID=1000
-# Proxy setting
-ENV http_proxy=""
-ENV https_proxy=""
 
 RUN apt-get update 
 # User setup

--- a/.devcontainer/environment/ubuntu/Dockerfile.gpu
+++ b/.devcontainer/environment/ubuntu/Dockerfile.gpu
@@ -13,14 +13,6 @@ ARG USE_MOBY="true"
 
 # Enable new "BUILDKIT" mode for Docker CLI
 ENV DOCKER_BUILDKIT=1
-# Install needed packages and setup non-root user. Use a separate RUN statement to add your
-# own dependencies. A user of "automatic" attempts to reuse an user ID if one already exists.
-ARG USERNAME=vscode
-ARG USER_UID=1000
-ARG USER_GID=1000
-# Proxy setting
-ENV http_proxy=""
-ENV https_proxy=""
 
 RUN apt-get update 
 # User setup


### PR DESCRIPTION
# 環境変数の設定を.envファイルとdockerfileの両方に書く必要がある

## 問題点
現状の構成では，環境変数（ユーザーID等とプロキシ）の設定を **.envファイル** と **dockerfile** の両方に書く必要がある．
この場合，環境ファイルに書き込む意味があまりなく，冗長である．
また，環境変数をハードコーディングすることになり，そのままGitHubにpushする場合はセキュリティの側面からも良くない．

## 提案方法
以下のQiitaの記事では，[docker-composeでのプロキシ設定を一つのファイルにまとめる方法](https://qiita.com/SolKul/items/2561c62734958c231b24) が紹介されている．
その中で，プロキシ設定の項目を docker-compose.ymlファイルの **build:** 配下だけではなく **environment:** 配下にも記述することで，立ち上がったコンテナでプロキシを使うための設定を行うことができると書かれている．

以上の内容を参考に，
①dockerfile からユーザーID等とプロキシの設定に該当するコードを削除し
②プロキシ設定の項目をdocker-compose.ymlファイルの  **environment:** 配下にも記述する
ことで，環境変数の設定を **.env** ファイルに統一することができる．

## 実行結果
上記の方法を適応し， `docker compose up -d --build` コマンドでコンテナを起動させた．
結果的には，問題なくプロキシサーバー外のネットワークと通信することができた．
（ `apt -y update` で問題なく動作できたことを確認した．）